### PR TITLE
FUN-2823 Force Identifier to String

### DIFF
--- a/lib/open_feature/flagsmith/provider/identity.rb
+++ b/lib/open_feature/flagsmith/provider/identity.rb
@@ -62,7 +62,7 @@ module OpenFeature
         attr_reader :traits
 
         def initialize(identifier:, transient:, traits:)
-          @identifier = identifier
+          @identifier = identifier.to_s # Flagsmith expects a string
           @transient = transient
           @traits = traits
         end


### PR DESCRIPTION
Ticket: [FUN-2823](https://forwardfinancing.atlassian.net/browse/FUN-2823)

Holy cow was this a gnarly one to run down. Turns out Flagsmith only accepts string identifiers, and the wrapper that we've written here passes the user ID as an integer. From now on, we force the identifier to be a String. 

[FUN-2823]: https://forwardfinancing.atlassian.net/browse/FUN-2823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ